### PR TITLE
changed links for emi from purl to w3id

### DIFF
--- a/src/common/constants.py
+++ b/src/common/constants.py
@@ -38,7 +38,7 @@ DCTERMS = Namespace("http://purl.org/dc/terms/")
 """
 
 # Custom namespace for EMI Box (for GloBI entity matching part)
-EMI_BOX_NAMESPACE = Namespace("https://purl.org/emi/abox#")
+EMI_BOX_NAMESPACE = Namespace("https://w3id.org/emi/abox#")
 
 SOSA = Namespace("http://www.w3.org/ns/sosa/") # From your inverse relations
 # Inverse relationships for RDF graph (for GloBI entity matching part)

--- a/src/knowledge_graph/globi_kg_generator.py
+++ b/src/knowledge_graph/globi_kg_generator.py
@@ -14,8 +14,8 @@ from src.knowledge_graph.globi_entity_matcher import GlobiEntityMatcher
 rdflib.plugin.register('turtle_custom', rdflib.plugin.Serializer, 'turtle_custom.serializer', 'TurtleSerializerCustom')
 
 # Namespace declarations
-EMI = Namespace("https://purl.org/emi#")
-EMIBOX = Namespace("https://purl.org/emi/abox#")
+EMI = Namespace("https://w3id.org/emi#")
+EMIBOX = Namespace("https://w3id.org/emi/abox#")
 SOSA = Namespace("http://www.w3.org/ns/sosa/")
 DCTERMS = Namespace("http://purl.org/dc/terms/")
 WD = Namespace("http://www.wikidata.org/entity/")

--- a/src/knowledge_graph/trydb_kg_generator.py
+++ b/src/knowledge_graph/trydb_kg_generator.py
@@ -13,9 +13,9 @@ from src.common.utils import format_uri, is_none_na_or_empty, create_dict_from_c
 rdflib.plugin.register('turtle_custom', rdflib.plugin.Serializer, 'turtle_custom.serializer', 'TurtleSerializerCustom')
 
 # Namespace declarations
-EMI = Namespace("https://purl.org/emi#")
-EMI_UNIT = Namespace("https://purl.org/emi/unit#")
-EMI_BOX = Namespace("https://purl.org/emi/abox#")
+EMI = Namespace("https://w3id.org/emi#")
+EMI_UNIT = Namespace("https://w3id.org/emi/unit#")
+EMI_BOX = Namespace("https://w3id.org/emi/abox#")
 SOSA = Namespace("http://www.w3.org/ns/sosa/")
 DCTERMS = Namespace("http://purl.org/dc/terms/")
 WD = Namespace("http://www.wikidata.org/entity/")


### PR DESCRIPTION
With reference to migration of EMI ontology from purl to w3id, certain changes in the python codes.